### PR TITLE
Feat/global-s3-upload

### DIFF
--- a/src/main/java/com/example/shortudy/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/shortudy/domain/user/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.example.shortudy.domain.user.controller;
 
 import com.example.shortudy.domain.user.dto.request.PasswordChangeRequest;
+import com.example.shortudy.domain.user.dto.request.PresignedUrlResponse;
+import com.example.shortudy.domain.user.dto.request.ProfileImageUpdateRequest;
 import com.example.shortudy.domain.user.dto.request.UpdateProfileRequest;
 import com.example.shortudy.global.security.principal.CustomUserDetails;
 import com.example.shortudy.domain.user.dto.request.SignUpRequest;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -42,6 +45,21 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @GetMapping("/me/profile/presigned-url")
+    public ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam String fileName) {
+        return ResponseEntity.ok(ApiResponse.success(userService.prepareProfileUpload(userDetails.getId(), fileName)));
+    }
+
+    @PatchMapping("/me/profile/image")
+    public ResponseEntity<ApiResponse<Void>> updateProfileImage(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                @RequestBody @Valid ProfileImageUpdateRequest request) {
+        userService.completeProfileUpdate(userDetails.getId(), request.newImageKey());
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    // TODO 프로필 수정 변경 예정 (프로필 사진 변경, 닉네임 변경 분리 예정)
     @PatchMapping("/me")
     public ResponseEntity<ApiResponse<Void>> updateProfile(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                            @RequestBody @Valid UpdateProfileRequest request) {

--- a/src/main/java/com/example/shortudy/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/shortudy/domain/user/controller/UserController.java
@@ -55,7 +55,7 @@ public class UserController {
     @PatchMapping("/me/profile/image")
     public ResponseEntity<ApiResponse<Void>> updateProfileImage(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                 @RequestBody @Valid ProfileImageUpdateRequest request) {
-        userService.completeProfileUpdate(userDetails.getId(), request.newImageKey());
+        userService.updateProfile(userDetails.getId(), request.newImageKey());
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 

--- a/src/main/java/com/example/shortudy/domain/user/dto/request/PresignedUrlResponse.java
+++ b/src/main/java/com/example/shortudy/domain/user/dto/request/PresignedUrlResponse.java
@@ -1,0 +1,7 @@
+package com.example.shortudy.domain.user.dto.request;
+
+public record PresignedUrlResponse(
+        String url,
+        String key
+) {
+}

--- a/src/main/java/com/example/shortudy/domain/user/dto/request/ProfileImageUpdateRequest.java
+++ b/src/main/java/com/example/shortudy/domain/user/dto/request/ProfileImageUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.example.shortudy.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ProfileImageUpdateRequest(
+        @NotBlank(message = "이미지 키는 필수입니다.")
+        @Pattern(
+                regexp = "^profiles/.*",
+                message = "올바른 프로필 이미지 경로가 아닙니다."
+        )
+        String newImageKey
+) {
+}

--- a/src/main/java/com/example/shortudy/domain/user/entity/User.java
+++ b/src/main/java/com/example/shortudy/domain/user/entity/User.java
@@ -40,6 +40,7 @@ public class User {
     @Column(nullable = false)
     private UserRole role;
 
+    // 전체 url이 아닌 profile image key 값만 저장
     @Column
     private String profileUrl;
 

--- a/src/main/java/com/example/shortudy/domain/user/service/UserService.java
+++ b/src/main/java/com/example/shortudy/domain/user/service/UserService.java
@@ -1,29 +1,41 @@
 package com.example.shortudy.domain.user.service;
 
 import com.example.shortudy.domain.user.dto.request.PasswordChangeRequest;
+import com.example.shortudy.domain.user.dto.request.PresignedUrlResponse;
 import com.example.shortudy.domain.user.dto.request.SignUpRequest;
 import com.example.shortudy.domain.user.dto.request.UpdateProfileRequest;
 import com.example.shortudy.domain.user.dto.response.InfoResponse;
 import com.example.shortudy.domain.user.entity.User;
 import com.example.shortudy.domain.user.entity.UserRole;
 import com.example.shortudy.domain.user.repository.UserRepository;
+import com.example.shortudy.global.config.S3Service;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import com.example.shortudy.global.error.BaseException;
 import com.example.shortudy.global.error.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 @Service
 @Transactional
+@Slf4j
 public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final S3Service s3Service;
+
+    //TODO application.yaml에 빼야하나?
+    private final long UPLOAD_PROFILE_MAX_FILE_SIZE = 5 * 1024 * 1024;  // 5MB 제한
 
     public UserService(UserRepository userRepository,
-                       PasswordEncoder passwordEncoder) {
+                       PasswordEncoder passwordEncoder,
+                       S3Service s3Service) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.s3Service = s3Service;
     }
 
     public void signup(SignUpRequest request) {
@@ -34,7 +46,6 @@ public class UserService {
 
         String encodedPassword = passwordEncoder.encode(request.password());
 
-        // TODO 현재 ADMIN 유저는 추가할 수 없음 추후 예정
         userRepository.save(User.create(
                 request.email(),
                 encodedPassword,
@@ -82,9 +93,72 @@ public class UserService {
         user.changePassword(passwordEncoder.encode(request.newPassword()));
     }
 
+
+    // DB 상태 변화를 일으키지 않기 때문에 Transactional 사용하지 않았음
+    // TODO 전체적인 flow를 분할시켰습니다. 추후 병합할 수 있는 부분 병합 예정
+    public PresignedUrlResponse prepareProfileUpload(Long userId, String uploadFileName) {
+
+        // 1. 파일 확장자 추출
+        String extension = uploadFileName.substring(uploadFileName.lastIndexOf("."));
+
+        // 2. ContentType 결정 로직 (private 함수로 결정)
+        String contentType = determineContentType(extension);
+
+        // 3. 고유한 파일 이름 생성 (중복 방지를 위해 UUID와 타임스탬프 활용)
+        String fileName = UUID.randomUUID() + "_" + System.currentTimeMillis() + extension;
+
+        // 4. S3 내의 경로 설정 (유지 보수를 위해 유저별 폴더를 나눔)
+        String key = "profiles/" + userId + "/" + fileName;
+
+        // 5. S3Service를 통해 임시 URL 발급, FE에게 "url에 올리고, 나중에 성공하면 이 key값을 나한테 다시 알려줘"라고 응답
+        return s3Service.getPresignedUrl(key, contentType, UPLOAD_PROFILE_MAX_FILE_SIZE);
+    }
+
+    // Content-Type 고정 값 및 제한
+    private String determineContentType(String extension) {
+        return switch (extension.toLowerCase()) {
+            case ".png" -> "image/png";
+            case ".jpg", ".jpeg" -> "image/jpeg";
+            //TODO gif도 필요?
+            default -> throw new BaseException(ErrorCode.UnsupportedImageFormatException);
+        };
+    }
+
+    @Transactional
+    public void completeProfileUpdate(Long userId, String newImageKey) {
+
+        // 보안 체크 (본인의 프로필이 아닌 것을 수정하려고 할 경우)
+        String expectedPrefix = "profiles/" + userId + "/";
+
+        if (!newImageKey.startsWith(expectedPrefix)) throw new BaseException(ErrorCode.AccessDeniedException);
+
+        // 1. DB에서 해당 유저를 찾기
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
+
+        // 2. 지워야 할 옛날 파일 경로
+        String oldImageKey = user.getProfileUrl();
+
+        // 3. DB를 먼저 새로운 경로로 업데이트
+        // [트랜잭션] 에러가 나면 아래의 삭제 로직은 실행되지 않음
+        user.changeProfileUrl(newImageKey);
+
+        // 4. 기존 사진이 있었다면 S3에서 제거
+        // 파일 삭제는 실패하더라도 유저의 프로필 변경(DB) 자체가 취소되지 않게 처리
+        if (oldImageKey != null && !oldImageKey.isEmpty()) {
+            try {
+                s3Service.deleteFile(oldImageKey);
+            } catch (Exception e) {
+                // 삭제 실패 시 로그를 남기고 넘김 (나중에 삭제 필요)
+                //TODO 로그로 남기는게 맞음? 아니면 변경을 막는게 맞나?
+                log.error("기존 프로필 파일 삭제 실패: {}", oldImageKey, e);
+            }
+        }
+    }
+
+    //TODO ADMIN(백오피스) 정책 의논 필요 -> FE분들이 ADMIN을 직접 DB에 넣는 작업을 하지 않기 위한 임시 서비스
     public void changeAdmin(Long userId) {
 
-        //TODO 자신은 ADMIN으로 변경이 불가능?, ADMIN -> USER로 권한 변경도 추가?, ADMIN만 ADMIN 설정 가능?
         User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
 
         user.changeRole();
@@ -95,6 +169,7 @@ public class UserService {
         return InfoResponse.from(userRepository.findById(userId).orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND)));
     }
 
+    //TODO User도 SoftDelete 해야할 것 같음 수정 예정
     public void deleteUser(Long userId) {
         userRepository.findById(userId).ifPresent(userRepository::delete);
     }

--- a/src/main/java/com/example/shortudy/global/config/S3Config.java
+++ b/src/main/java/com/example/shortudy/global/config/S3Config.java
@@ -1,0 +1,50 @@
+package com.example.shortudy.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    private final AwsProperties awsProperties;
+
+    public S3Config(AwsProperties awsProperties) {
+        this.awsProperties = awsProperties;
+    }
+
+    /**
+     * 서명된 URL(Presigned URL)을 만드는 전용 도구입니다.
+     * 실제로 S3와 통신하지 않고, 서버 내부에서 암호화 알고리즘만 돌려서 URL을 생성합니다.
+     */
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(awsProperties.getRegion()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(
+                                awsProperties.getCredentials().getAccessKey(),
+                                awsProperties.getCredentials().getSecretKey()
+                        ))).build();
+    }
+
+    /**
+     * S3에 직접 명령을 내리는 도구입니다. (파일 삭제, 목록 조회 등)
+     * 실제로 AWS S3 서버와 네트워크 통신을 합니다.
+     */
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(awsProperties.getRegion()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(
+                                awsProperties.getCredentials().getAccessKey(),
+                                awsProperties.getCredentials().getSecretKey()
+                        )))
+                .build();
+    }
+}

--- a/src/main/java/com/example/shortudy/global/config/S3Service.java
+++ b/src/main/java/com/example/shortudy/global/config/S3Service.java
@@ -1,0 +1,72 @@
+package com.example.shortudy.global.config;
+
+import com.example.shortudy.domain.user.dto.request.PresignedUrlResponse;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+
+@Service
+public class S3Service {
+
+    private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
+    private final AwsProperties awsProperties;
+
+    public S3Service(S3Presigner s3Presigner, S3Client s3Client, AwsProperties awsProperties) {
+        this.s3Presigner = s3Presigner;
+        this.s3Client = s3Client;
+        this.awsProperties = awsProperties;
+    }
+
+    /**
+     * @param key: S3에 저장될 파일의 전체 경로 (ex: profile/1/image.png)
+     * @param contentType: 파일 형식(ex: image/png)이 다르면 S3가 업로드를 거부
+     * @param contentLength: 제한할 파일 크기(Byte 단위)가 넘으면 S3가 업로드 거부
+     */
+    public PresignedUrlResponse getPresignedUrl(String key, String contentType, long contentLength) {
+
+        // S3에게 아래 조건의 업로드를 허가해주는 요청서를 만듭니다.
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(awsProperties.getS3().getBucket())
+                .key(key)   // URL 경로에 자동으로 포함
+                .contentType(contentType)   // [검증] 이 타입이 아니면 업로드 거부됨
+                .contentLength(contentLength)   // [검증] 이 크기보다 크면 업로드 거부
+                .build();
+
+        // 위 요청서에 서명을 입혀 임시 URL로 변환
+        PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5))   // 5분뒤 자동 폐기
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        // 서버가 가진 Secret Key를 이용해 수학적으로 계산(Sign)만 해서 URL을 생성
+        PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putObjectPresignRequest);
+
+        // http(s) 형태의 전체 주소
+        String url = presignedPutObjectRequest.url().toString();
+
+        return new PresignedUrlResponse(url, key);
+    }
+
+    //TODO S3내 파일을 조회하는 로직 필요?
+
+    /**
+     * @param key: 삭제할 파일의 경로
+     * S3 서버에 저장된 파일을 삭제하라고 지시
+     */
+    public void deleteFile(String key) {
+
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(awsProperties.getS3().getBucket())
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(deleteObjectRequest);
+    }
+}

--- a/src/main/java/com/example/shortudy/global/error/ErrorCode.java
+++ b/src/main/java/com/example/shortudy/global/error/ErrorCode.java
@@ -22,6 +22,8 @@ public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "USER_401", "토큰이 만료되었습니다."),
     SAME_PASSWORD(HttpStatus.BAD_REQUEST, "USER_401", "변경할 비밀번호가 현재 비밀번호와 같습니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "USER_409", "이미 사용중인 별명입니다."),
+    UnsupportedImageFormatException(HttpStatus.BAD_REQUEST, "USER_400", "유저 프로필 이미지에 적합하지 않은 파일 유형입니다."),
+    AccessDeniedException(HttpStatus.FORBIDDEN, "USER_403", "본인의 프로필 이미지만 설정할 수 있습니다."),
 
 
     // category


### PR DESCRIPTION
1. 변경 사항
유저 프로필 이미지를 서버를 거치지 않고 S3에 직접 업로드하는 Presigned URL 방식을 도입했습니다. 이를 통해 서버의 네트워크 부하를 줄이고 효율적인 파일 관리가 가능하도록 설계했습니다.

1. 변경 이유 및 내역
S3 인프라 설정 및 공통 서비스 구현
S3Config: AWS SDK 연동을 위한 Bean 설정 (S3Presigner, S3Client)
S3Service: 도메인에 독립적인 범용 Presigned URL 발급 및 오브젝트 삭제 로직 구현

2단계 업로드 프로세스 도입
Step 1 (발급): 유저별 고유 경로(profiles/{userId}/uuid_timestamp.ext)를 포함한 PUT URL 생성
Step 2 (확정): 업로드 성공 후 FE로부터 받은 Key를 DB에 반영하고, 기존 프로필 이미지 자동 삭제

보안 강화
@AuthenticationPrincipal을 사용하여 본인 경로 외의 접근 차단
DTO 내 @Pattern 검증을 통해 유효하지 않은 경로의 DB 등록 방지
파일 크기(5MB) 및 Content-Type(이미지 전용) 제한 적용

Closes #103 