### PR TITLE
refactor[keyword] :  키워드 관련 API 및 서비스 리팩토링

### DIFF
--- a/src/main/java/com/example/shortudy/domain/keyword/controller/KeywordController.java
+++ b/src/main/java/com/example/shortudy/domain/keyword/controller/KeywordController.java
@@ -40,6 +40,7 @@ public class KeywordController {
 //    }
 
     // 키워드 검색 기능
+    @Deprecated(since = "해당 API는 제거될 가능성이 있습니다.")
     @GetMapping("/search")
     public ResponseEntity<ApiResponse<List<KeywordResponse>>> search(
             @RequestParam(value = "q", required = false) String q) {

--- a/src/main/java/com/example/shortudy/domain/keyword/controller/KeywordController.java
+++ b/src/main/java/com/example/shortudy/domain/keyword/controller/KeywordController.java
@@ -21,18 +21,25 @@ public class KeywordController {
     }
 
 
+    // 키워드 전체 조회. (FE에서는 이 API만 사용중)
     @GetMapping
     public ResponseEntity<ApiResponse<List<KeywordResponse>>> getAllKeywords() {
         List<KeywordResponse> response = keywordService.getAllKeywords();
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<KeywordResponse>> getById(@PathVariable Long id) {
-        KeywordResponse response = keywordService.getKeyword(id);
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
+    //  키워드 ID로 조회 ?..
+    /*
+    * TODO : 해당 API가 실제로 필요한지 검토 필요.
+    *  필요 없으면 삭제 예정.
+    * */
+//    @GetMapping("/{id}")
+//    public ResponseEntity<ApiResponse<KeywordResponse>> getById(@PathVariable Long id) {
+//        KeywordResponse response = keywordService.getKeyword(id);
+//        return ResponseEntity.ok(ApiResponse.success(response));
+//    }
 
+    // 키워드 검색 기능
     @GetMapping("/search")
     public ResponseEntity<ApiResponse<List<KeywordResponse>>> search(
             @RequestParam(value = "q", required = false) String q) {
@@ -40,6 +47,7 @@ public class KeywordController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    // 키워드 생성 (Admin)
     @PostMapping
     public ResponseEntity<ApiResponse<KeywordResponse>> create(@RequestBody KeywordRequest req) {
         // [수정] req.displayName() 대신 req.name() 사용 (KeywordRequest 레코드 규격)
@@ -48,6 +56,7 @@ public class KeywordController {
                 .body(ApiResponse.success(created));
     }
 
+    // 키워드 업데이트 (Admin) - 필요한가 ?
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponse<KeywordResponse>> update(
             @PathVariable Long id,
@@ -57,6 +66,7 @@ public class KeywordController {
         return ResponseEntity.ok(ApiResponse.success(updated));
     }
 
+    // 키워드 삭제 (Admin) - 필요한가 ?
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id) {
         keywordService.deleteKeyword(id);

--- a/src/main/java/com/example/shortudy/domain/keyword/service/KeywordService.java
+++ b/src/main/java/com/example/shortudy/domain/keyword/service/KeywordService.java
@@ -29,12 +29,16 @@ public class KeywordService {
                 .collect(Collectors.toList());
     }
 
-    @Transactional(readOnly = true)
-    public KeywordResponse getKeyword(Long keywordId) {
-        return keywordRepository.findById(keywordId)
-                .map(this::toResponse)
-                .orElseThrow(() -> new BaseException(ErrorCode.KEYWORD_NOT_FOUND));
-    }
+    /*
+    * TODO : 해당 API가 실제로 필요한지 검토 필요.
+    *  필요 없으면 삭제 예정.
+    * */
+//    @Transactional(readOnly = true)
+//    public KeywordResponse getKeyword(Long keywordId) {
+//        return keywordRepository.findById(keywordId)
+//                .map(this::toResponse)
+//                .orElseThrow(() -> new BaseException(ErrorCode.KEYWORD_NOT_FOUND));
+//    }
 
     @Transactional(readOnly = true)
     public List<KeywordResponse> searchKeywords(String q) {

--- a/src/main/java/com/example/shortudy/domain/keyword/service/KeywordService.java
+++ b/src/main/java/com/example/shortudy/domain/keyword/service/KeywordService.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional(readOnly = true)
 public class KeywordService {
 
     private final KeywordRepository keywordRepository;
@@ -22,7 +23,6 @@ public class KeywordService {
         this.keywordRepository = keywordRepository;
     }
 
-    @Transactional(readOnly = true)
     public List<KeywordResponse> getAllKeywords() {
         return keywordRepository.findAll().stream()
                 .map(this::toResponse)
@@ -40,7 +40,7 @@ public class KeywordService {
 //                .orElseThrow(() -> new BaseException(ErrorCode.KEYWORD_NOT_FOUND));
 //    }
 
-    @Transactional(readOnly = true)
+    @Deprecated(since = "해당 메서드는 제거될 가능성이 있습니다.")
     public List<KeywordResponse> searchKeywords(String q) {
         if (q == null || q.isBlank()) return List.of();
 


### PR DESCRIPTION
## 변경 사항
- 키워드 단일 조회 API 주석처리
- 키워드 검색 조회 API `@Deprecated` 처리
## 변경 이유
- 키워드를 기반으로 Shorts를 검색하는 일은 있는데, 단일 조회를 User가 사용할 일이 없다고 판단함.
- 키워드 검색 조회 API도 현재 FE에서 전체 키워드를 받아 필터링 하고 있고, 관리자가 키워드를 관리하기로 설계를 해뒀기 때문에 불필요하다고 판단했습니다.  
## 주요 변경 내역
-
## 관련 이슈
-