### PR TITLE
refactor[user] : 업로드한 사진 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/shortudy/domain/user/dto/response/InfoResponse.java
+++ b/src/main/java/com/example/shortudy/domain/user/dto/response/InfoResponse.java
@@ -8,12 +8,4 @@ public record InfoResponse(
         String nickName,
         String profileUrl
 ) {
-
-    public static InfoResponse from(User user) {
-        return new InfoResponse(
-                user.getId(),
-                user.getEmail(),
-                user.getNickname(),
-                user.getProfileUrl());
-    }
 }

--- a/src/main/java/com/example/shortudy/global/config/S3Service.java
+++ b/src/main/java/com/example/shortudy/global/config/S3Service.java
@@ -1,6 +1,8 @@
 package com.example.shortudy.global.config;
 
 import com.example.shortudy.domain.user.dto.request.PresignedUrlResponse;
+import com.example.shortudy.global.error.BaseException;
+import com.example.shortudy.global.error.ErrorCode;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -27,16 +29,14 @@ public class S3Service {
     /**
      * @param key: S3에 저장될 파일의 전체 경로 (ex: profile/1/image.png)
      * @param contentType: 파일 형식(ex: image/png)이 다르면 S3가 업로드를 거부
-     * @param contentLength: 제한할 파일 크기(Byte 단위)가 넘으면 S3가 업로드 거부
      */
-    public PresignedUrlResponse getPresignedUrl(String key, String contentType, long contentLength) {
+    public PresignedUrlResponse getPresignedUrl(String key, String contentType) {
 
         // S3에게 아래 조건의 업로드를 허가해주는 요청서를 만듭니다.
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(awsProperties.getS3().getBucket())
                 .key(key)   // URL 경로에 자동으로 포함
                 .contentType(contentType)   // [검증] 이 타입이 아니면 업로드 거부됨
-                .contentLength(contentLength)   // [검증] 이 크기보다 크면 업로드 거부
                 .build();
 
         // 위 요청서에 서명을 입혀 임시 URL로 변환
@@ -55,6 +55,14 @@ public class S3Service {
     }
 
     //TODO S3내 파일을 조회하는 로직 필요?
+
+    // Key -> URL로
+    public String getFileUrl(String key) {
+        // 유저가 프로필을 등록하지 않았을 때
+        if (key == null) return null;
+
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", awsProperties.getS3().getBucket(), awsProperties.getRegion(), key);
+    }
 
     /**
      * @param key: 삭제할 파일의 경로

--- a/src/main/java/com/example/shortudy/global/error/ErrorCode.java
+++ b/src/main/java/com/example/shortudy/global/error/ErrorCode.java
@@ -24,7 +24,7 @@ public enum ErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "USER_409", "이미 사용중인 별명입니다."),
     UnsupportedImageFormatException(HttpStatus.BAD_REQUEST, "USER_400", "유저 프로필 이미지에 적합하지 않은 파일 유형입니다."),
     AccessDeniedException(HttpStatus.FORBIDDEN, "USER_403", "본인의 프로필 이미지만 설정할 수 있습니다."),
-    UserDeleteNotAllowedException(HttpStatus.CONFLICT, "USER_409", "다른 도메인이 참조 중인 사용자입니다."),
+    UserDeleteNotAllowedException(HttpStatus.CONFLICT, "USER_409", "회원 탈퇴가 불가능한 회원입니다."),
 
 
     // category

--- a/src/main/java/com/example/shortudy/global/error/ErrorCode.java
+++ b/src/main/java/com/example/shortudy/global/error/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "USER_409", "이미 사용중인 별명입니다."),
     UnsupportedImageFormatException(HttpStatus.BAD_REQUEST, "USER_400", "유저 프로필 이미지에 적합하지 않은 파일 유형입니다."),
     AccessDeniedException(HttpStatus.FORBIDDEN, "USER_403", "본인의 프로필 이미지만 설정할 수 있습니다."),
+    UserDeleteNotAllowedException(HttpStatus.CONFLICT, "USER_409", "다른 도메인이 참조 중인 사용자입니다."),
 
 
     // category


### PR DESCRIPTION
[FEAT] S3 업로드 로직 개선 및 유저 삭제 시 참조 예외 처리 추가

1. 개요 (Summary)
S3 Presigned URL 생성 로직에서 불필요한 제약 사항을 제거하고(contentLength), 유저 삭제 시 발생할 수 있는 참조 무결성 위반에 대한 에러 핸들링을 강화했습니다.

2. 주요 변경 사항 (Key Changes)
1. S3 Presigned URL 생성 시 contentLength 파라미터 삭제
- 클라이언트에서 업로드할 파일의 크기를 미리 확정하기 어려운 경우를 고려하여, 백엔드에서 강제하던 contentLength 제약을 제거했습니다. 이로 인해 업로드 로직의 유연성이 확보되었습니다.
2. 유저 삭제 시 참조 무결성 예외(DataIntegrityViolationException) 처리
- 타 도메인(게시글, 주문 등)에서 해당 유저를 FK로 참조하고 있어 삭제가 불가능할 경우, 구체적인 에러 코드(예: UserDeleteNotAllowedException)를 반환하도록 로직을 추가했습니다.