### PR TITLE
refactor[comments] : 대댓글 API 로직 수정

### DIFF
--- a/src/main/java/com/example/shortudy/domain/comment/controller/ReplyController.java
+++ b/src/main/java/com/example/shortudy/domain/comment/controller/ReplyController.java
@@ -72,7 +72,8 @@ public class ReplyController {
             @AuthenticationPrincipal CustomUserDetails me,
             @PathVariable Long replyId
     ) {
-        commentService.deleteComment(me.getId(), replyId);
+        // NOTE : 대댓글을 삭제하는 메서드 추가
+        commentService.deleteCommentReply(me.getId(), replyId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/example/shortudy/domain/comment/controller/ReplyController.java
+++ b/src/main/java/com/example/shortudy/domain/comment/controller/ReplyController.java
@@ -60,7 +60,8 @@ public class ReplyController {
             @PathVariable Long replyId,
             @Valid @RequestBody CommentRequest request
     ) {
-        commentService.updateComment(me.getId(), replyId, request);
+        // NOTE : 대댓글을 삭제하는 메서드 추가
+        commentService.updateCommentReply(me.getId(), replyId, request);
 
         return ResponseEntity.ok(ApiResponse.success(null)
         );

--- a/src/main/java/com/example/shortudy/domain/comment/controller/ReplyController.java
+++ b/src/main/java/com/example/shortudy/domain/comment/controller/ReplyController.java
@@ -60,7 +60,7 @@ public class ReplyController {
             @PathVariable Long replyId,
             @Valid @RequestBody CommentRequest request
     ) {
-        // NOTE : 대댓글을 삭제하는 메서드 추가
+        // NOTE : 대댓글을 업데이트하는 메서드 추가
         commentService.updateCommentReply(me.getId(), replyId, request);
 
         return ResponseEntity.ok(ApiResponse.success(null)

--- a/src/main/java/com/example/shortudy/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/shortudy/domain/comment/entity/Comment.java
@@ -101,6 +101,12 @@ public class Comment {
 
     // 대댓글
     public static Comment reply(User user, Comment parent, String content) {
+
+        // Comment parent가 대댓글인 경우 예외 처리
+        if (parent.getParent() != null) {
+            throw new BaseException(ErrorCode.COMMENT_NOT_FOUND);
+        }
+
         return new Comment(user, parent.getShorts(), parent, content);
     }
 

--- a/src/main/java/com/example/shortudy/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/shortudy/domain/comment/entity/Comment.java
@@ -116,6 +116,7 @@ public class Comment {
             throw new BaseException(ErrorCode.COMMENT_FORBIDDEN);
         }
 
+        // NOTE : 멱등성을 위해서 return을 해줘도 되긴 함 !
         if (this.status == CommentStatus.DELETED) {
             return; // 이미 삭제된 경우 아무 작업도 수행하지 않음
         }

--- a/src/main/java/com/example/shortudy/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/shortudy/domain/comment/service/CommentService.java
@@ -70,13 +70,34 @@ public class CommentService {
         return new CommentListResponse(totalCount, commentResponses);
     }
 
-    // 댓글, 대댓글 수정
+    // 댓글 수정
     @Transactional
     public void updateComment(Long userId, Long commentId, CommentRequest request) {
 
         Comment comment = commentRepository.findById(commentId).orElseThrow(() ->
                 new BaseException(ErrorCode.COMMENT_NOT_FOUND));
 
+        if (!comment.isWrittenBy(userId)) {
+            throw new BaseException(ErrorCode.COMMENT_FORBIDDEN);
+        } else {
+            comment.updateContent(request.content());
+        }
+    }
+
+    // TODO : 대댓글 업데이트 로직 분리를 위한 메서드 추가
+    @Transactional
+    public void updateCommentReply(Long userId, Long commentId, CommentRequest request) {
+
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() ->
+            new BaseException(ErrorCode.COMMENT_NOT_FOUND));
+
+
+        // 대댓글이 아닌 경우 예외 처리
+        if (comment.getParent() == null) {
+            throw new BaseException(ErrorCode.COMMENT_NOT_FOUND);
+        }
+
+        // 작성자 검증
         if (!comment.isWrittenBy(userId)) {
             throw new BaseException(ErrorCode.COMMENT_FORBIDDEN);
         } else {

--- a/src/main/java/com/example/shortudy/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/shortudy/domain/comment/service/CommentService.java
@@ -5,6 +5,7 @@ import com.example.shortudy.domain.comment.dto.response.CommentListResponse;
 import com.example.shortudy.domain.comment.dto.response.CommentResponse;
 import com.example.shortudy.domain.comment.dto.response.ReplyResponse;
 import com.example.shortudy.domain.comment.entity.Comment;
+import com.example.shortudy.domain.comment.entity.CommentStatus;
 import com.example.shortudy.domain.comment.query.CommentCountProvider;
 import com.example.shortudy.domain.comment.repository.CommentRepository;
 import com.example.shortudy.domain.shorts.entity.Shorts;
@@ -84,7 +85,7 @@ public class CommentService {
         }
     }
 
-    // TODO : 대댓글 업데이트 로직 분리를 위한 메서드 추가
+    // NOTE : 대댓글 업데이트 로직 분리를 위한 메서드 추가
     @Transactional
     public void updateCommentReply(Long userId, Long commentId, CommentRequest request) {
 
@@ -95,6 +96,11 @@ public class CommentService {
         // 대댓글이 아닌 경우 예외 처리
         if (comment.getParent() == null) {
             throw new BaseException(ErrorCode.COMMENT_NOT_FOUND);
+        }
+
+        // 댓글이 삭제되어있는 경우 예외 처리
+        if (comment.getStatus() == CommentStatus.DELETED) {
+            throw new BaseException(ErrorCode.COMMENT_DELETED);
         }
 
         // 작성자 검증

--- a/src/main/java/com/example/shortudy/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/shortudy/domain/comment/service/CommentService.java
@@ -105,7 +105,7 @@ public class CommentService {
         }
     }
 
-    // 댓글, 대댓글 삭제
+    // 댓글 삭제
     @Transactional
     public void deleteComment(Long userId, Long commentId) {
 
@@ -123,6 +123,28 @@ public class CommentService {
                 reply.softDelete(reply.getUser().getId()); // 대댓글 작성자 권한으로 삭제 처리 (혹은 강제 삭제)
             }
         }
+
+        comment.softDelete(userId);
+    }
+
+    // TODO : 대댓글 삭제 메서드 분리
+    @Transactional
+    public void deleteCommentReply(Long userId, Long commentId) {
+
+        // 대댓글 ID가 없으면 예외 처리
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() ->
+            new BaseException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // 내가 쓴 대댓글이 아니면 오류 처리
+        if (!comment.isWrittenBy(userId)) {
+            throw new BaseException(ErrorCode.COMMENT_FORBIDDEN);
+        }
+
+        // 대댓글이 아닌 경우 예외 처리
+        if (comment.getParent() == null) {
+            throw new BaseException(ErrorCode.COMMENT_NOT_FOUND);
+        }
+
 
         comment.softDelete(userId);
     }

--- a/src/main/java/com/example/shortudy/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/shortudy/domain/comment/service/CommentService.java
@@ -123,6 +123,14 @@ public class CommentService {
     @Transactional(readOnly = true)
     public List<ReplyResponse> findReplies(Long parentId, Long myIdOrNull) {
 
+        // NOTE: 부모 댓글이 대댓글인 경우 예외 처리
+        Comment parentComment = commentRepository.findById(parentId).orElseThrow(() ->
+                new BaseException(ErrorCode.COMMENT_NOT_FOUND));
+        if (parentComment.getParent() != null) {
+            // 이 경우는 대댓글인 경우
+            throw new BaseException(ErrorCode.COMMENT_NOT_FOUND);
+        }
+
         List<Comment> replies = commentRepository.findRepliesWithUser(parentId);
 
         return replies.stream()

--- a/src/main/java/com/example/shortudy/global/error/ErrorCode.java
+++ b/src/main/java/com/example/shortudy/global/error/ErrorCode.java
@@ -50,6 +50,7 @@ public enum ErrorCode {
     // comment
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_404", "해당 댓글을 찾을 수 없습니다."),
     COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMENT_403", "해당 댓글에 대한 접근 권한이 없습니다."),
+    COMMENT_DELETED(HttpStatus.BAD_REQUEST, "COMMENT_400", "삭제된 댓글입니다."),
 
     // Keyword
     KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD_404", "해당 키워드를 찾을 수 없습니다."),


### PR DESCRIPTION
변경 사항
- reply API의 로직을 수정했습니다.
변경 이유
- 대댓글의 댓글을 생성할 수 있어서 로직을 수정했습니다.
- 대댓글이랑 댓글 수정, 삭제 로직이 동일한 로직을 타고 있어서 메서드 분리했습니다.
- 삭제된 대댓글을 수정할 때, Exception처리 되지 않아서 Exception 처리했습니다. 
주요 변경 내역
-
관련 이슈
- 대댓글 삭제 API를 계속 호출하면 204 응답이 계속 오는데, 멱등성 측면에서 괜찮다고 합니다 !
