### PR TITLE
fix[user]: Reject blank email on profile update

### DIFF
--- a/src/main/java/com/example/shortudy/domain/user/service/UserService.java
+++ b/src/main/java/com/example/shortudy/domain/user/service/UserService.java
@@ -58,6 +58,8 @@ public class UserService {
 
         boolean changed = false;
 
+        if (request.email() != null && request.email().isBlank()) throw new BaseException(ErrorCode.EmailBlankException);
+
         if (request.email() != null) {
             if (userRepository.existsByEmail(request.email())) throw new BaseException(ErrorCode.DUPLICATE_EMAIL);
             user.changeEmail(request.email());

--- a/src/main/java/com/example/shortudy/global/error/ErrorCode.java
+++ b/src/main/java/com/example/shortudy/global/error/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     UnsupportedImageFormatException(HttpStatus.BAD_REQUEST, "USER_400", "유저 프로필 이미지에 적합하지 않은 파일 유형입니다."),
     AccessDeniedException(HttpStatus.FORBIDDEN, "USER_403", "본인의 프로필 이미지만 설정할 수 있습니다."),
     UserDeleteNotAllowedException(HttpStatus.CONFLICT, "USER_409", "회원 탈퇴가 불가능한 회원입니다."),
+    EmailBlankException(HttpStatus.BAD_REQUEST, "USER_400", "이메일은 빈 값을 입력할 수 없습니다."),
 
 
     // category


### PR DESCRIPTION
### 작업 내용
- 프로필 수정 시 빈 이메일 값이 들어오면 에러를 반환하도록 처리

### 작업 이유
- 유효하지 않은 요청을 사전에 차단하기 위함

### 영향 범위
- 빈 이메일 요청 시 400 Bad Request 반환
- 기존 정상 수정 로직에는 영향 없음