### PR TITLE
refactor[short] : 반려 사유 추가

### DIFF
--- a/src/main/java/com/example/shortudy/domain/shorts/controller/ShortsController.java
+++ b/src/main/java/com/example/shortudy/domain/shorts/controller/ShortsController.java
@@ -1,6 +1,7 @@
 package com.example.shortudy.domain.shorts.controller;
 
 import com.example.shortudy.domain.shorts.dto.ShortsResponse;
+import com.example.shortudy.domain.shorts.dto.ShortsStatusDescriptionResponse;
 import com.example.shortudy.domain.shorts.dto.ShortsUpdateRequest;
 import com.example.shortudy.domain.shorts.service.ShortsQueryService;
 import com.example.shortudy.domain.shorts.service.ShortsService;
@@ -48,11 +49,11 @@ public class ShortsController {
 
     @GetMapping("/me")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<Page<ShortsResponse>> getMyShorts(
+    public ApiResponse<Page<ShortsStatusDescriptionResponse>> getMyShorts(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 20, sort = "id", direction = DESC) Pageable pageable
     ) {
-        Page<ShortsResponse> response = shortsQueryService.getMyShorts(userDetails.getId(), pageable);
+        Page<ShortsStatusDescriptionResponse> response = shortsQueryService.getMyShorts(userDetails.getId(), pageable);
         return ApiResponse.success(response);
     }
 

--- a/src/main/java/com/example/shortudy/domain/shorts/dto/ShortsStatusDescriptionResponse.java
+++ b/src/main/java/com/example/shortudy/domain/shorts/dto/ShortsStatusDescriptionResponse.java
@@ -1,0 +1,56 @@
+package com.example.shortudy.domain.shorts.dto;
+
+import com.example.shortudy.domain.shorts.entity.ShortsStatus;
+import com.example.shortudy.domain.shorts.entity.ShortsVisibility;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ShortsStatusDescriptionResponse(
+    Long shortsId,
+    String title,
+    String description,
+    String videoUrl,
+    String thumbnailUrl,
+    Integer durationSec,
+    ShortsStatus status,
+    String shortsStatusDescription,
+    ShortsVisibility visibility,
+    Long userId,
+    String userNickname,
+    String userProfileUrl,
+    Long categoryId,
+    String categoryName,
+    List<String> keywords,
+    Long viewCount,
+    Integer likeCount,
+    Long commentCount,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    Boolean isLiked
+) {
+    public static ShortsStatusDescriptionResponse of(ShortsResponse response, String shortsStatusDescription) {
+        return new ShortsStatusDescriptionResponse(
+            response.shortsId(),
+            response.title(),
+            response.description(),
+            response.videoUrl(),
+            response.thumbnailUrl(),
+            response.durationSec(),
+            response.status(),
+            shortsStatusDescription,
+            response.visibility(),
+            response.userId(),
+            response.userNickname(),
+            response.userProfileUrl(),
+            response.categoryId(),
+            response.categoryName(),
+            response.keywords(),
+            response.viewCount(),
+            response.likeCount(),
+            response.commentCount(),
+            response.createdAt(),
+            response.updatedAt(),
+            response.isLiked()
+        );
+    }
+}

--- a/src/main/java/com/example/shortudy/domain/shorts/entity/InspectionStatus.java
+++ b/src/main/java/com/example/shortudy/domain/shorts/entity/InspectionStatus.java
@@ -1,0 +1,6 @@
+package com.example.shortudy.domain.shorts.entity;
+
+public enum InspectionStatus {
+    APPROVED,
+    REJECTED,
+}

--- a/src/main/java/com/example/shortudy/domain/shorts/entity/Shorts.java
+++ b/src/main/java/com/example/shortudy/domain/shorts/entity/Shorts.java
@@ -95,10 +95,6 @@ public class Shorts {
     @Column(name = "status")
     private ShortsStatus status;
 
-    // nullable
-    @Column(name = "reject_reason")
-    private String rejectReason;
-
     @OneToMany(mappedBy = "shorts", fetch = FetchType.LAZY,
             cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ShortsKeyword> shortsKeywords = new ArrayList<>();
@@ -257,18 +253,4 @@ public class Shorts {
         return this.status == ShortsStatus.PENDING;
     }
 
-    // 숏츠의 상태에 따라 ShortsStatusDescription을 반환한다.
-    public String getStatusDescription() {
-        // reject reason이 있으면 반환
-        if (rejectReason != null && this.status == ShortsStatus.REJECT) {
-            return rejectReason;
-        }
-
-        return switch (this.status) {
-            case PENDING -> "검토 중..";
-            case AI_CHECK -> "1차 검수 완료";
-            case PUBLISHED -> "게시됨";
-            case REJECT -> "거부됨";
-        };
-    }
 }

--- a/src/main/java/com/example/shortudy/domain/shorts/entity/Shorts.java
+++ b/src/main/java/com/example/shortudy/domain/shorts/entity/Shorts.java
@@ -95,6 +95,10 @@ public class Shorts {
     @Column(name = "status")
     private ShortsStatus status;
 
+    // nullable
+    @Column(name = "reject_reason")
+    private String rejectReason;
+
     @OneToMany(mappedBy = "shorts", fetch = FetchType.LAZY,
             cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ShortsKeyword> shortsKeywords = new ArrayList<>();
@@ -251,5 +255,20 @@ public class Shorts {
     // 업로드 미완료 세션 정리 시, 고아 숏츠로 삭제 가능한지 판단한다.
     public boolean canBeDeletedAsUploadOrphan() {
         return this.status == ShortsStatus.PENDING;
+    }
+
+    // 숏츠의 상태에 따라 ShortsStatusDescription을 반환한다.
+    public String getStatusDescription() {
+        // reject reason이 있으면 반환
+        if (rejectReason != null && this.status == ShortsStatus.REJECT) {
+            return rejectReason;
+        }
+
+        return switch (this.status) {
+            case PENDING -> "검토 중..";
+            case AI_CHECK -> "1차 검수 완료";
+            case PUBLISHED -> "게시됨";
+            case REJECT -> "거부됨";
+        };
     }
 }

--- a/src/main/java/com/example/shortudy/domain/shorts/entity/ShortsInspectionResults.java
+++ b/src/main/java/com/example/shortudy/domain/shorts/entity/ShortsInspectionResults.java
@@ -1,0 +1,48 @@
+package com.example.shortudy.domain.shorts.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "shorts_inspection_results")
+public class ShortsInspectionResults implements Serializable {
+
+    @Id
+    @Column(name = "id")
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "shorts_id")
+    private Shorts shorts;
+
+    @Column(name = "author")
+    private String author;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "inspection_status")
+    private InspectionStatus inspectionStatus;
+
+    @Column(name = "category")
+    private String category;
+
+    @Column(name = "confidence_score")
+    private Float confidenceScore;
+
+    @Column(name = "reason")
+    private String reason;
+
+    @Column(name = "registed_at")
+    private LocalDateTime registedAt;
+
+
+}

--- a/src/main/java/com/example/shortudy/domain/shorts/repository/ShortsInspectionResultsRepository.java
+++ b/src/main/java/com/example/shortudy/domain/shorts/repository/ShortsInspectionResultsRepository.java
@@ -1,0 +1,10 @@
+package com.example.shortudy.domain.shorts.repository;
+
+import com.example.shortudy.domain.shorts.entity.ShortsInspectionResults;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShortsInspectionResultsRepository extends JpaRepository<ShortsInspectionResults, Long> {
+
+    Optional<ShortsInspectionResults> findByShortsId(Long shortsId);
+}

--- a/src/main/java/com/example/shortudy/domain/shorts/repository/ShortsInspectionResultsRepository.java
+++ b/src/main/java/com/example/shortudy/domain/shorts/repository/ShortsInspectionResultsRepository.java
@@ -1,10 +1,15 @@
 package com.example.shortudy.domain.shorts.repository;
 
 import com.example.shortudy.domain.shorts.entity.ShortsInspectionResults;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ShortsInspectionResultsRepository extends JpaRepository<ShortsInspectionResults, Long> {
 
     Optional<ShortsInspectionResults> findByShortsId(Long shortsId);
+
+    // ✅ N+1 방지용
+    List<ShortsInspectionResults> findByShortsIdIn(Collection<Long> shortsIds);
 }

--- a/src/main/java/com/example/shortudy/domain/upload/dto/ShortsUploadStatusResponse.java
+++ b/src/main/java/com/example/shortudy/domain/upload/dto/ShortsUploadStatusResponse.java
@@ -13,7 +13,7 @@ public record ShortsUploadStatusResponse(
         Long shortId,
         String uploadStatus,
         ShortsStatus shortsStatus,
-        String shortsStatusLabel,
+        String shortsStatusDescription,
         String videoUrl,
         String thumbnailUrl,
         Integer durationSec,

--- a/src/main/java/com/example/shortudy/domain/upload/dto/ShortsUploadStatusResponse.java
+++ b/src/main/java/com/example/shortudy/domain/upload/dto/ShortsUploadStatusResponse.java
@@ -13,6 +13,7 @@ public record ShortsUploadStatusResponse(
         Long shortId,
         String uploadStatus,
         ShortsStatus shortsStatus,
+        String shortsStatusLabel,
         String videoUrl,
         String thumbnailUrl,
         Integer durationSec,

--- a/src/main/java/com/example/shortudy/domain/upload/service/ShortsUploadStatusService.java
+++ b/src/main/java/com/example/shortudy/domain/upload/service/ShortsUploadStatusService.java
@@ -56,6 +56,7 @@ public class ShortsUploadStatusService {
                 shortId,
                 uploadStatus,
                 shorts.getStatus(),
+                shorts.getStatusDescription(),
                 session.getVideoUrl(),
                 session.getThumbnailUrl(),
                 session.getDurationSec(),

--- a/src/main/java/com/example/shortudy/domain/upload/service/ShortsUploadStatusService.java
+++ b/src/main/java/com/example/shortudy/domain/upload/service/ShortsUploadStatusService.java
@@ -1,6 +1,8 @@
 package com.example.shortudy.domain.upload.service;
 
 import com.example.shortudy.domain.shorts.entity.Shorts;
+import com.example.shortudy.domain.shorts.entity.ShortsInspectionResults;
+import com.example.shortudy.domain.shorts.repository.ShortsInspectionResultsRepository;
 import com.example.shortudy.domain.shorts.repository.ShortsRepository;
 import com.example.shortudy.domain.upload.dto.ShortsUploadStatusResponse;
 import com.example.shortudy.domain.upload.entity.ShortsUploadSession;
@@ -22,13 +24,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class ShortsUploadStatusService {
 
     private final ShortsUploadSessionRepository uploadSessionRepository;
+    private final ShortsInspectionResultsRepository shortsInspectionResultsRepository;
     private final ShortsRepository shortsRepository;
 
     public ShortsUploadStatusService(
             ShortsUploadSessionRepository uploadSessionRepository,
+            ShortsInspectionResultsRepository shortsInspectionResultsRepository,
             ShortsRepository shortsRepository
     ) {
         this.uploadSessionRepository = uploadSessionRepository;
+        this.shortsInspectionResultsRepository = shortsInspectionResultsRepository;
         this.shortsRepository = shortsRepository;
     }
 
@@ -52,11 +57,25 @@ public class ShortsUploadStatusService {
 
         String uploadStatus = mapUploadStatus(session.getStatus());
 
+        // NOTE : null로 반환하는 이유는 프론트에서 상태에 따라 UI를 다르게 처리하기 위함입니다.
+        ShortsInspectionResults shortsInspectionResult = shortsInspectionResultsRepository.findByShortsId(shortId)
+                .orElse(null);
+
+        String inspectionResult;
+
+        // default = 반려 사유를 inspection에서 맵핑해오는 로직
+        switch (shorts.getStatus()) {
+            case PENDING -> inspectionResult = "심사 대기 중입니다.";
+            case AI_CHECK -> inspectionResult = "AI 심사 중입니다.";
+            case PUBLISHED -> inspectionResult = "게시된 숏츠입니다.";
+            default -> inspectionResult = shortsInspectionResult != null ? shortsInspectionResult.getReason() : null;
+        }
+
         return new ShortsUploadStatusResponse(
                 shortId,
                 uploadStatus,
                 shorts.getStatus(),
-                shorts.getStatusDescription(),
+                inspectionResult,
                 session.getVideoUrl(),
                 session.getThumbnailUrl(),
                 session.getDurationSec(),


### PR DESCRIPTION
## 변경 사항
- `Short` : rejectReason Column 추가, ShortStatusDescription 메서드 추가
- `ShortUploadStatusResponse` : 응답 메시지에 shortsStatusLabel 필드 추가
- `ShortsUploadStatusService` : 변경된 response에 필드 맵핑
- `ShortsInspectionResult` : AI가 검수한 내용을 저장하는 테이블 추가
## 변경 이유
- short reject된 이유에 대해서 프론트에서 명시해주기 위함.
